### PR TITLE
Add Tool Registry and Retrieval Tooling

### DIFF
--- a/src/gregg_limper/clients/oai.py
+++ b/src/gregg_limper/clients/oai.py
@@ -148,8 +148,24 @@ async def chat(
         ]
     """
     resp = await aoai.chat.completions.create(
-       model=model,
-       messages=messages,
+        model=model,
+        messages=messages,
     )
 
     return resp.choices[0].message.content.strip()
+
+
+async def chat_full(
+    messages: list[dict],
+    *,
+    model=core.MSG_MODEL_ID,
+    tools: list[dict] | None = None,
+    tool_choice: str | None = None,
+):
+    """Return the raw OpenAI chat completion response (optionally with tools)."""
+    kwargs = {"model": model, "messages": messages}
+    if tools:
+        kwargs["tools"] = tools
+        if tool_choice:
+            kwargs["tool_choice"] = tool_choice
+    return await aoai.chat.completions.create(**kwargs)

--- a/src/gregg_limper/formatter/model.py
+++ b/src/gregg_limper/formatter/model.py
@@ -1,6 +1,5 @@
-from __future__ import annotations
-
-"""Dataclass models for formatter fragments.
+"""
+Dataclass models for formatter fragments.
 
 Fragment schema (output of :meth:`Fragment.to_dict`):
 
@@ -18,6 +17,7 @@ extras. Objects keep only non-``None`` attributes when serialized. ``id`` is a
 stable identifier assigned during composition.
 """
 
+from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Optional, Literal, Dict, Any
 

--- a/src/gregg_limper/response/__init__.py
+++ b/src/gregg_limper/response/__init__.py
@@ -5,11 +5,18 @@ from __future__ import annotations
 import json
 import logging
 from pathlib import Path
+from typing import Any, Iterable
 
 import discord
 
 from gregg_limper.clients import oai, ollama
 from gregg_limper.config import core, local_llm
+from gregg_limper.tools import (
+    ToolContext,
+    ToolExecutionError,
+    get_registered_tool_specs,
+)
+from gregg_limper.tools.executor import execute_tool
 
 from .pipeline import build_prompt_payload
 
@@ -21,13 +28,111 @@ async def handle(message: discord.Message) -> str:
 
     payload = await build_prompt_payload(message)
 
-    _write_debug_file("debug_history.md", payload.history.messages)
-    _write_debug_file("debug_context.md", payload.context.semantic_memory)
-    _write_debug_file("debug_messages.json", payload.messages, json_dump=True)
+    tool_specs = get_registered_tool_specs()
+    use_tools = bool(tool_specs) and not local_llm.USE_LOCAL
 
-    if local_llm.USE_LOCAL:
-        return await ollama.chat(payload.messages, model=local_llm.LOCAL_MODEL_ID)
-    return await oai.chat(payload.messages, model=core.MSG_MODEL_ID)
+    messages = list(payload.messages)
+
+    if local_llm.USE_LOCAL or not use_tools:
+        result_text = (
+            await ollama.chat(messages, model=local_llm.LOCAL_MODEL_ID)
+            if local_llm.USE_LOCAL
+            else await oai.chat(messages, model=core.MSG_MODEL_ID)
+        )
+        _write_debug_payload(payload, messages)
+        return result_text
+
+    result_text, final_messages = await _run_with_tools(
+        messages=messages,
+        tool_specs=tool_specs,
+        context=ToolContext(
+            guild_id=getattr(message.guild, "id", None),
+            channel_id=getattr(message.channel, "id", None),
+            message_id=getattr(message, "id", None),
+        ),
+    )
+    _write_debug_payload(payload, final_messages)
+    return result_text
+
+
+def _write_debug_payload(payload, final_messages: Iterable[dict[str, str]]) -> None:
+    _write_debug_file("debug_history.md", payload.history.messages)
+    _write_debug_file("debug_context.md", payload.context.user_profiles)
+    _write_debug_file("debug_messages.json", list(final_messages), json_dump=True)
+
+
+async def _run_with_tools(*, messages, tool_specs, context: ToolContext) -> tuple[str, list[dict[str, str]]]:
+    openai_tools = [spec.to_openai() for spec in tool_specs]
+    conversation = list(messages)
+    max_iters = 5
+
+    cached_tool_results: dict[tuple[str, str], str] = {}
+
+    for _ in range(max_iters):
+        resp = await oai.chat_full(
+            conversation,
+            model=core.MSG_MODEL_ID,
+            tools=openai_tools,
+        )
+        choice = resp.choices[0]
+        message = choice.message
+        assistant_content = message.content or ""
+        tool_calls = getattr(message, "tool_calls", None) or []
+
+        assistant_entry: dict[str, Any] = {
+            "role": "assistant",
+            "content": assistant_content,
+        }
+
+        if tool_calls:
+            assistant_entry["tool_calls"] = [
+                {
+                    "id": getattr(call, "id", None),
+                    "type": "function",
+                    "function": {
+                        "name": getattr(call.function, "name", None),
+                        "arguments": getattr(call.function, "arguments", "{}"),
+                    },
+                }
+                for call in tool_calls
+            ]
+
+        conversation.append(assistant_entry)
+
+        if not tool_calls:
+            return assistant_content.strip(), conversation
+
+        for call in tool_calls:
+            name = getattr(call.function, "name", None)
+            arguments = getattr(call.function, "arguments", "{}")
+            if not name:
+                continue
+            logger.info(
+                "Executing tool call id=%s name=%s arguments=%s",
+                getattr(call, "id", None),
+                name,
+                arguments,
+            )
+            cache_key = (name, arguments)
+            if cache_key in cached_tool_results:
+                content = cached_tool_results[cache_key]
+            else:
+                try:
+                    result = await execute_tool(name, arguments, context=context)
+                    content = result.content
+                except ToolExecutionError as exc:
+                    content = f"Tool '{name}' failed: {exc}"
+                cached_tool_results[cache_key] = content
+            conversation.append(
+                {
+                    "role": "tool",
+                    "tool_call_id": getattr(call, "id", None),
+                    "name": name,
+                    "content": content,
+                }
+            )
+
+    raise RuntimeError("Exceeded maximum tool call iterations")
 
 
 def _write_debug_file(
@@ -55,4 +160,4 @@ def _write_debug_file(
         logger.debug("Failed to write %s: %s", filename, exc)
 
 
-__all__ = ["handle"]
+__all__ = ["handle", "_run_with_tools"]

--- a/src/gregg_limper/response/context.py
+++ b/src/gregg_limper/response/context.py
@@ -5,18 +5,14 @@ from __future__ import annotations
 import asyncio
 import logging
 from dataclasses import dataclass
-from typing import Any, Iterable, Sequence
+from typing import Any, Iterable
 
 from discord import Message
 
-from gregg_limper.clients import disc
-from gregg_limper.config import core, prompt
-from gregg_limper.memory.cache import GLCache
 from gregg_limper.memory.rag import consent
 from gregg_limper.memory.rag import (
     channel_summary as fetch_channel_summary,
     user_profile as fetch_user_profile,
-    vector_search,
 )
 
 logger = logging.getLogger(__name__)
@@ -28,13 +24,17 @@ class ConversationContext:
 
     channel_summary: str | None
     user_profiles: list[dict[str, Any]]
-    semantic_memory: list[dict[str, Any]]
 
 
 async def gather_context(
     message: Message, *, participant_ids: Iterable[int]
 ) -> ConversationContext:
-    """Collect all dynamic context required for a reply."""
+    """
+    Collect all dynamic context required for a reply.
+    
+    NOTE: Tool-based retrieval now surfaces richer semantic context on demand.
+    This function remains for surfacing channel summaries and user profiles.
+    """
 
     channel_summary_task = asyncio.create_task(
         fetch_channel_summary(message.channel.id)
@@ -42,18 +42,14 @@ async def gather_context(
     user_profiles_task = asyncio.create_task(
         _gather_user_profiles(participant_ids)
     )
-    semantic_memory_task = asyncio.create_task(_gather_semantic_memory(message))
-
-    channel_summary, user_profiles, semantic_memory = await asyncio.gather(
+    channel_summary, user_profiles = await asyncio.gather(
         channel_summary_task,
         user_profiles_task,
-        semantic_memory_task,
     )
 
     return ConversationContext(
         channel_summary=channel_summary,
         user_profiles=user_profiles,
-        semantic_memory=semantic_memory,
     )
 
 
@@ -78,150 +74,6 @@ async def _gather_user_profiles(
 
     profiles = await asyncio.gather(*(fetch_user_profile(pid) for pid in consenting))
     return [profile for profile in profiles if profile]
-
-
-async def _gather_semantic_memory(message: Message) -> list[dict[str, Any]]:
-    """Retrieve semantic memories relevant to the provided message."""
-
-    fragments = _collect_fragment_text(message)
-    if not fragments:
-        return []
-
-    per_fragment_candidates = await asyncio.gather(
-        *(_vector_search_across_channels(message, fragment) for fragment in fragments)
-    )
-
-    semantic_candidates = _merge_semantic_candidates(
-        per_fragment_candidates, prompt.VECTOR_SEARCH_K
-    )
-    if not semantic_candidates:
-        return []
-
-    author_lookup = await _map_author_display_names(semantic_candidates)
-    formatted: list[dict[str, Any]] = []
-    for candidate in semantic_candidates:
-        author_id = candidate.get("author_id")
-        formatted.append(
-            {
-                "author": author_lookup.get(author_id, _fallback_author_name(author_id)),
-                "title": candidate.get("title"),
-                "content": candidate.get("content"),
-                "type": candidate.get("type"),
-                "url": candidate.get("url"),
-            }
-        )
-
-    return formatted
-
-
-def _collect_fragment_text(message: Message) -> list[str]:
-    """Return textual fragments cached for the given message."""
-
-    cache = GLCache()
-    memo_record = cache.get_memo_record(message.channel.id, message.id)
-    fragments = memo_record.get("fragments", [])
-
-    contents: list[str] = []
-    for fragment in fragments:
-        content = fragment.content_text()
-        if content and content.strip():
-            contents.append(content.strip())
-
-    logger.info("Fragment contents for vector search: %s", contents)
-    return contents
-
-
-async def _vector_search_across_channels(
-    message: Message, content: str
-) -> list[dict[str, Any]]:
-    """Run a vector search for the content across configured channels."""
-
-    fragment_candidates: list[dict[str, Any]] = []
-    for channel_id in core.CHANNEL_IDS:
-        results = await vector_search(
-            message.guild.id,
-            channel_id,
-            content,
-            k=prompt.VECTOR_SEARCH_K + 1,
-        )
-        filtered = [
-            candidate
-            for candidate in results
-            if candidate.get("message_id") != message.id
-        ]
-        fragment_candidates.extend(filtered)
-
-    return fragment_candidates
-
-
-def _merge_semantic_candidates(
-    per_fragment_candidates: Sequence[Sequence[dict[str, Any]]],
-    limit: int,
-) -> list[dict[str, Any]]:
-    """Merge semantic search results ensuring diversity and uniqueness."""
-
-    if not per_fragment_candidates or limit <= 0:
-        return []
-
-    merged: list[dict[str, Any]] = []
-    seen_ids: set[int] = set()
-    indices = [0] * len(per_fragment_candidates)
-
-    while len(merged) < limit:
-        progress_made = False
-        for frag_idx, candidates in enumerate(per_fragment_candidates):
-            if len(merged) >= limit:
-                break
-
-            while indices[frag_idx] < len(candidates):
-                candidate = candidates[indices[frag_idx]]
-                indices[frag_idx] += 1
-
-                candidate_id = candidate.get("id")
-                if candidate_id is not None:
-                    if candidate_id in seen_ids:
-                        continue
-                    seen_ids.add(candidate_id)
-
-                merged.append(candidate)
-                progress_made = True
-                break
-
-        if not progress_made:
-            break
-
-    return merged
-
-
-async def _map_author_display_names(
-    candidates: Iterable[dict[str, Any]]
-) -> dict[int, str]:
-    """Fetch Discord display names for candidate authors."""
-
-    author_ids = {
-        candidate.get("author_id")
-        for candidate in candidates
-        if candidate.get("author_id") is not None
-    }
-
-    author_names: dict[int, str] = {}
-    for author_id in author_ids:
-        try:
-            user = await disc.bot.fetch_user(author_id)
-        except Exception as exc:  # pragma: no cover - defensive logging
-            logger.warning(
-                "Failed to fetch author %s display name: %s", author_id, exc
-            )
-            continue
-        author_names[author_id] = user.display_name
-
-    return author_names
-
-
-def _fallback_author_name(author_id: Any) -> str:
-    if author_id is None:
-        return "Unknown"
-    return str(author_id)
 
 
 __all__ = ["ConversationContext", "gather_context"]

--- a/src/gregg_limper/response/context_messages.py
+++ b/src/gregg_limper/response/context_messages.py
@@ -32,15 +32,6 @@ def build_context_messages(context: ConversationContext) -> list[dict[str, str]]
         )
     )
 
-    sections.append(
-        _format_section(
-            "Semantic Memory",
-            _format_semantic_memory(context.semantic_memory)
-            if context.semantic_memory
-            else "_No related memories were found in the vector store._",
-        )
-    )
-
     content = "\n\n".join(sections).strip()
     if not content:
         return []
@@ -62,11 +53,4 @@ def _format_user_profiles(profiles: Iterable[dict]) -> str:
         f"- {json.dumps(profile, ensure_ascii=False, indent=2)}" for profile in profiles
     ]
     return "\n".join(serialized)
-
-
-def _format_semantic_memory(memories: Iterable[dict]) -> str:
-    if not memories:
-        return ""
-    serialized = json.dumps(list(memories), ensure_ascii=False, indent=2)
-    return f"```json\n{serialized}\n```"
 

--- a/src/gregg_limper/response/pipeline.py
+++ b/src/gregg_limper/response/pipeline.py
@@ -8,6 +8,7 @@ from typing import List
 from discord import Message
 
 from gregg_limper.config import core
+from gregg_limper.tools import build_tool_prompt, get_registered_tool_specs
 
 from .context import ConversationContext, gather_context
 from .context_messages import build_context_messages
@@ -37,8 +38,11 @@ async def build_prompt_payload(message: Message) -> PromptPayload:
     messages: list[dict[str, str]] = [
         {"role": "system", "content": get_system_prompt()}
     ]
+
+    tool_specs = get_registered_tool_specs()
+    if tool_specs:
+        messages.append({"role": "assistant", "content": build_tool_prompt(tool_specs)})
     messages.extend(build_context_messages(context))
     messages.extend(history.messages)
 
     return PromptPayload(messages=messages, history=history, context=context)
-

--- a/src/gregg_limper/tools/__init__.py
+++ b/src/gregg_limper/tools/__init__.py
@@ -1,4 +1,9 @@
-"""Tool registry and base classes for model assistance."""
+"""Tool registry and base classes for model assistance.
+
+Handlers under :mod:`gregg_limper.tools.handlers` register themselves here via
+decorators. The response pipeline in turn exposes the registry to OpenAI tools
+and executes tool calls at runtime.
+"""
 
 from __future__ import annotations
 
@@ -20,11 +25,15 @@ __all__ = [
 
 @dataclass(slots=True)
 class ToolSpec:
+    """Static description of a tool exposed to the LLM."""
+
     name: str
     description: str
     parameters: Dict[str, Any]
 
     def to_openai(self) -> Dict[str, Any]:
+        """Return this spec formatted for OpenAI function calling."""
+
         return {
             "type": "function",
             "function": {
@@ -37,6 +46,8 @@ class ToolSpec:
 
 @dataclass(slots=True)
 class ToolContext:
+    """Runtime metadata describing the Discord message being serviced."""
+
     guild_id: int | None
     channel_id: int | None
     message_id: int | None
@@ -44,17 +55,25 @@ class ToolContext:
 
 @dataclass(slots=True)
 class ToolResult:
+    """Normalized tool output returned to the LLM."""
+
     content: str
 
 
 class ToolExecutionError(RuntimeError):
+    """Raised when a tool fails to execute successfully."""
+
     pass
 
 
 class Tool:
+    """Base class for concrete tool handlers."""
+
     spec: ToolSpec
 
     async def run(self, *, context: ToolContext, **kwargs: Any) -> ToolResult:
+        """Execute the tool and return a :class:`ToolResult`."""
+
         raise NotImplementedError
 
 
@@ -63,6 +82,7 @@ _handlers_loaded = False
 
 
 def register_tool(spec: ToolSpec):
+    """Class decorator that binds ``spec`` to the decorated :class:`Tool`."""
     def decorator(cls: Type[Tool]) -> Type[Tool]:
         if not issubclass(cls, Tool):
             raise TypeError("Tool registrations must derive from Tool")
@@ -76,16 +96,22 @@ def register_tool(spec: ToolSpec):
 
 
 def get_registered_tool_specs() -> List[ToolSpec]:
+    """Return all registered specs, ensuring handlers are imported."""
+
     _ensure_handlers_loaded()
     return [entry.spec for entry in _registry.values()]
 
 
 def get_tool_entry(name: str) -> Type[Tool] | None:
+    """Return the registered :class:`Tool` subclass for ``name``."""
+
     _ensure_handlers_loaded()
     return _registry.get(name)
 
 
 def build_tool_prompt(specs: Iterable[ToolSpec]) -> str:
+    """Render a succinct Markdown description of available tools."""
+
     lines = ["### Tools", "The assistant can call these tools when helpful:"]
     for spec in specs:
         lines.append(f"- **{spec.name}**: {spec.description}")
@@ -93,6 +119,8 @@ def build_tool_prompt(specs: Iterable[ToolSpec]) -> str:
 
 
 def _ensure_handlers_loaded() -> None:
+    """Import handler modules so decorator side-effects fire once."""
+
     global _handlers_loaded
     if _handlers_loaded:
         return

--- a/src/gregg_limper/tools/__init__.py
+++ b/src/gregg_limper/tools/__init__.py
@@ -1,0 +1,102 @@
+"""Tool registry and base classes for model assistance."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List, Type
+
+__all__ = [
+    "Tool",
+    "ToolContext",
+    "ToolResult",
+    "ToolSpec",
+    "ToolExecutionError",
+    "build_tool_prompt",
+    "get_registered_tool_specs",
+    "get_tool_entry",
+    "register_tool",
+]
+
+
+@dataclass(slots=True)
+class ToolSpec:
+    name: str
+    description: str
+    parameters: Dict[str, Any]
+
+    def to_openai(self) -> Dict[str, Any]:
+        return {
+            "type": "function",
+            "function": {
+                "name": self.name,
+                "description": self.description,
+                "parameters": self.parameters,
+            },
+        }
+
+
+@dataclass(slots=True)
+class ToolContext:
+    guild_id: int | None
+    channel_id: int | None
+    message_id: int | None
+
+
+@dataclass(slots=True)
+class ToolResult:
+    content: str
+
+
+class ToolExecutionError(RuntimeError):
+    pass
+
+
+class Tool:
+    spec: ToolSpec
+
+    async def run(self, *, context: ToolContext, **kwargs: Any) -> ToolResult:
+        raise NotImplementedError
+
+
+_registry: dict[str, Type[Tool]] = {}
+_handlers_loaded = False
+
+
+def register_tool(spec: ToolSpec):
+    def decorator(cls: Type[Tool]) -> Type[Tool]:
+        if not issubclass(cls, Tool):
+            raise TypeError("Tool registrations must derive from Tool")
+        if spec.name in _registry:
+            raise ValueError(f"Tool with name '{spec.name}' already registered")
+        cls.spec = spec
+        _registry[spec.name] = cls
+        return cls
+
+    return decorator
+
+
+def get_registered_tool_specs() -> List[ToolSpec]:
+    _ensure_handlers_loaded()
+    return [entry.spec for entry in _registry.values()]
+
+
+def get_tool_entry(name: str) -> Type[Tool] | None:
+    _ensure_handlers_loaded()
+    return _registry.get(name)
+
+
+def build_tool_prompt(specs: Iterable[ToolSpec]) -> str:
+    lines = ["### Tools", "The assistant can call these tools when helpful:"]
+    for spec in specs:
+        lines.append(f"- **{spec.name}**: {spec.description}")
+    return "\n".join(lines)
+
+
+def _ensure_handlers_loaded() -> None:
+    global _handlers_loaded
+    if _handlers_loaded:
+        return
+    # Import side-effects register built-in tools
+    from . import handlers  # noqa: F401
+
+    _handlers_loaded = True

--- a/src/gregg_limper/tools/executor.py
+++ b/src/gregg_limper/tools/executor.py
@@ -1,0 +1,32 @@
+"""Tool execution helpers."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from . import ToolContext, ToolExecutionError, ToolResult, get_tool_entry
+
+
+async def execute_tool(name: str, arguments: str | dict[str, Any], *, context: ToolContext) -> ToolResult:
+    entry = get_tool_entry(name)
+    if entry is None:
+        raise ToolExecutionError(f"Unknown tool '{name}'")
+
+    if isinstance(arguments, str):
+        try:
+            parsed_args = json.loads(arguments) if arguments.strip() else {}
+        except json.JSONDecodeError as exc:
+            raise ToolExecutionError(f"Invalid JSON arguments for tool '{name}': {exc}") from exc
+    else:
+        parsed_args = arguments
+
+    tool = entry()
+    try:
+        return await tool.run(context=context, **parsed_args)
+    except ToolExecutionError:
+        raise
+    except TypeError as exc:
+        raise ToolExecutionError(str(exc)) from exc
+    except Exception as exc:  # pragma: no cover - defensive guard
+        raise ToolExecutionError(f"Tool '{name}' execution failed: {exc}") from exc

--- a/src/gregg_limper/tools/executor.py
+++ b/src/gregg_limper/tools/executor.py
@@ -9,6 +9,14 @@ from . import ToolContext, ToolExecutionError, ToolResult, get_tool_entry
 
 
 async def execute_tool(name: str, arguments: str | dict[str, Any], *, context: ToolContext) -> ToolResult:
+    """
+    Execute the registered tool ``name`` with ``arguments``.
+
+    ``arguments`` may be a JSON string (as provided by OpenAI) or a parsed
+    mapping.  The helper normalises the payload, instantiates the tool class,
+    and returns its :class:`ToolResult`.
+    """
+
     entry = get_tool_entry(name)
     if entry is None:
         raise ToolExecutionError(f"Unknown tool '{name}'")

--- a/src/gregg_limper/tools/handlers/__init__.py
+++ b/src/gregg_limper/tools/handlers/__init__.py
@@ -1,0 +1,6 @@
+"""Built-in tool handlers."""
+
+from __future__ import annotations
+
+# Import concrete tools so they register
+from . import rag  # noqa: F401

--- a/src/gregg_limper/tools/handlers/__init__.py
+++ b/src/gregg_limper/tools/handlers/__init__.py
@@ -1,6 +1,11 @@
-"""Built-in tool handlers."""
+"""
+Import side-effects for tool handlers.
+
+Every module imported here should register itself with the tool registry using
+the :func:`gregg_limper.tools.register_tool` decorator.
+"""
 
 from __future__ import annotations
 
-# Import concrete tools so they register
+# Import concrete tools so module-level decorators execute on import.
 from . import rag  # noqa: F401

--- a/src/gregg_limper/tools/handlers/rag.py
+++ b/src/gregg_limper/tools/handlers/rag.py
@@ -33,7 +33,11 @@ from .. import Tool, ToolContext, ToolResult, ToolSpec, ToolExecutionError, regi
     )
 )
 class RetrieveContextTool(Tool):
+    """Fetch cached context using the existing RAG vector search."""
+
     async def run(self, *, context: ToolContext, **kwargs: Any) -> ToolResult:
+        """Return a ranked list of matching fragments or a fallback message."""
+
         query = kwargs.get("query")
         if not query or not isinstance(query, str):
             raise ToolExecutionError("'query' must be supplied as a string")

--- a/src/gregg_limper/tools/handlers/rag.py
+++ b/src/gregg_limper/tools/handlers/rag.py
@@ -1,0 +1,61 @@
+"""Tool for retrieving contextual memories via RAG."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from gregg_limper.memory import rag
+
+from .. import Tool, ToolContext, ToolResult, ToolSpec, ToolExecutionError, register_tool
+
+
+@register_tool(
+    ToolSpec(
+        name="retrieve_context",
+        description="Search cached memories relevant to the given query.",
+        parameters={
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": "Natural language search query.",
+                },
+                "k": {
+                    "type": "integer",
+                    "description": "Maximum number of results to return (1-6).",
+                    "minimum": 1,
+                    "maximum": 6,
+                    "default": 3,
+                },
+            },
+            "required": ["query"],
+        },
+    )
+)
+class RetrieveContextTool(Tool):
+    async def run(self, *, context: ToolContext, **kwargs: Any) -> ToolResult:
+        query = kwargs.get("query")
+        if not query or not isinstance(query, str):
+            raise ToolExecutionError("'query' must be supplied as a string")
+
+        k = kwargs.get("k", 3)
+        if not isinstance(k, int):
+            raise ToolExecutionError("'k' must be an integer")
+        k = max(1, min(6, k))
+
+        guild_id = context.guild_id
+        channel_id = context.channel_id
+        if guild_id is None or channel_id is None:
+            raise ToolExecutionError("Missing guild or channel context for retrieval")
+
+        results = await rag.vector_search(guild_id, channel_id, query, k=k)
+        if not results:
+            return ToolResult(content="No related context was found.")
+
+        lines: list[str] = []
+        for idx, row in enumerate(results, start=1):
+            snippet = row.get("content") or row.get("title") or "(no content)"
+            author = row.get("author_id") or "unknown"
+            lines.append(f"{idx}. {snippet} (author: {author}, message: {row.get('message_id')})")
+
+        return ToolResult(content="\n".join(lines))

--- a/tests/response/test_tool_loop.py
+++ b/tests/response/test_tool_loop.py
@@ -1,0 +1,71 @@
+import asyncio
+
+from gregg_limper.config import core
+from gregg_limper.response import _run_with_tools
+from gregg_limper.tools import ToolContext, ToolResult, ToolSpec
+
+
+class DummyFunction:
+    def __init__(self, name: str, arguments: str):
+        self.name = name
+        self.arguments = arguments
+
+
+class DummyCall:
+    def __init__(self, name: str, arguments: str, call_id: str):
+        self.id = call_id
+        self.function = DummyFunction(name, arguments)
+
+
+class DummyMessage:
+    def __init__(self, content: str, tool_calls=None):
+        self.content = content
+        self.tool_calls = tool_calls or []
+
+
+class DummyChoice:
+    def __init__(self, message):
+        self.message = message
+        self.finish_reason = "stop"
+
+
+class DummyResponse:
+    def __init__(self, message):
+        self.choices = [DummyChoice(message)]
+
+
+class DummyToolSpec(ToolSpec):
+    def to_openai(self):
+        return {"type": "function", "function": {"name": self.name, "description": self.description, "parameters": self.parameters}}
+
+
+def test_run_with_tools_executes_loop(monkeypatch):
+    specs = [DummyToolSpec(name="dummy", description="test", parameters={"type": "object", "properties": {}})]
+
+    sequence = [
+        DummyResponse(DummyMessage("", [DummyCall("dummy", "{}", "call-1")])),
+        DummyResponse(DummyMessage("Final answer")),
+    ]
+
+    async def fake_chat_full(messages, model, tools):
+        assert model == core.MSG_MODEL_ID
+        return sequence.pop(0)
+
+    async def fake_execute_tool(name, arguments, context):
+        assert name == "dummy"
+        return ToolResult(content="tool-output")
+
+    monkeypatch.setattr("gregg_limper.clients.oai.chat_full", fake_chat_full)
+    monkeypatch.setattr("gregg_limper.response.execute_tool", fake_execute_tool)
+
+    text, conversation = asyncio.run(
+        _run_with_tools(
+            messages=[{"role": "system", "content": "sys"}],
+            tool_specs=specs,
+            context=ToolContext(guild_id=1, channel_id=2, message_id=3),
+        )
+    )
+
+    assert text == "Final answer"
+    roles = [msg["role"] for msg in conversation]
+    assert "tool" in roles

--- a/tests/tools/test_tools.py
+++ b/tests/tools/test_tools.py
@@ -1,0 +1,36 @@
+import asyncio
+
+import pytest
+
+from gregg_limper.tools import ToolContext, get_registered_tool_specs
+from gregg_limper.tools.executor import execute_tool
+
+
+def test_registry_exposes_default_tool():
+    names = {spec.name for spec in get_registered_tool_specs()}
+    assert "retrieve_context" in names
+
+
+def test_execute_tool_uses_rag(monkeypatch):
+    async def fake_vector_search(guild_id, channel_id, query, k):
+        assert guild_id == 42
+        assert channel_id == 13
+        assert query == "pizza"
+        assert k == 2
+        return [
+            {"content": "Cheese pizza", "author_id": 1, "message_id": 100},
+            {"content": "Pepperoni pizza", "author_id": 2, "message_id": 101},
+        ]
+
+    monkeypatch.setattr("gregg_limper.tools.handlers.rag.rag.vector_search", fake_vector_search)
+
+    result = asyncio.run(
+        execute_tool(
+            "retrieve_context",
+            {"query": "pizza", "k": 2},
+            context=ToolContext(guild_id=42, channel_id=13, message_id=7),
+        )
+    )
+
+    assert "Cheese pizza" in result.content
+    assert "Pepperoni pizza" in result.content


### PR DESCRIPTION
- Introduce a tools/ package with a decorator-driven registry, execution helpers, and the first retrieve_context tool
- Surface tool availability in the response pipeline, implement OpenAI tool-call handling (loop, logging, and duplicate-call caching)
- Streamline context gathering by moving semantic retrieval behind the new tool, enrich debugging artifacts, and add targeted tests/documentation for tool support