### PR TITLE
Normalize handler registries and document registry workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ The tables below highlight the specifics for each subsystem.
 | Directory | `src/gregg_limper/formatter/handlers/` |
 | Decorator | `formatter.handlers.register` |
 | Runtime API | `formatter.handlers.get(media_type)` |
-| When adding | Update `formatter/composer.py`’s `ORDER`, teach `formatter/classifier.py` how to populate the slice, and ensure the corresponding `Fragment` class implements `content_text` for RAG ingestion. |
+| When adding | Update `formatter/composer.py`’s `ORDER`, teach `formatter/classifier.py` how to populate the slice, and ensure the corresponding `Fragment` class implements `content_text` for RAG ingestion (see `src/gregg_limper/formatter/handlers/__init__.py`). |
 
 ### Command Cogs
 | Item | Location / Notes |
@@ -250,7 +250,7 @@ The tables below highlight the specifics for each subsystem.
 | Directory | `src/gregg_limper/commands/handlers/` |
 | Decorator | `commands.register_cog` |
 | Runtime API | `commands.setup(bot)` attaches every registered cog |
-| When adding | Provide any Discord slash command definitions within the Cog, note that modules are imported eagerly, and run the bot (or `pytest tests/test_commands_setup.py`) to validate registration. |
+| When adding | Provide any Discord slash command definitions within the Cog, note that modules are imported eagerly, and run the bot (or `pytest tests/test_commands_setup.py`) to validate registration (see `src/gregg_limper/commands/__init__.py`). |
 
 ### Tool Handlers
 | Item | Location / Notes |
@@ -258,7 +258,7 @@ The tables below highlight the specifics for each subsystem.
 | Directory | `src/gregg_limper/tools/handlers/` |
 | Decorator | `tools.register_tool` |
 | Runtime API | `tools.get_registered_tool_specs()` / `tools.get_tool_entry(name)` |
-| When adding | Return a `ToolResult` from `run`, add or update tests in `tests/tools/`, consider logging/timeout behaviour, and document new configuration knobs if needed. |
+| When adding | Return a `ToolResult` from `run`, add or update tests in `tests/tools/`, consider logging/timeout behaviour, and document new configuration knobs if needed (see `src/gregg_limper/tools/__init__.py`). |
 
 ## Development Notes
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Discord assistant for knowledge retrieval and response generation. Gregg Limper 
   - [Run the Test Suite](#run-the-test-suite)
 - [Slash Commands](#slash-commands)
 - [Configuration Reference](#configuration-reference)
+- [Handler Registries](#handler-registries)
 - [Development Notes](#development-notes)
 - [Troubleshooting & Debugging](#troubleshooting--debugging)
 - [Further Reading](#further-reading)
@@ -227,6 +228,37 @@ Additional commands can be added by creating new handlers under `src/gregg_limpe
 | `USE_LOCAL` | `0` | When truthy, `response.handle` calls Ollama instead of OpenAI chat. |
 | `LOCAL_MODEL_ID` | `gpt-oss-20b` | Ollama model identifier. |
 | `LOCAL_SERVER_URL` | `http://localhost:11434` | Ollama server address. |
+
+## Handler Registries
+
+Formatter handlers, command cogs, and tool handlers all follow the same pattern:
+modules live under a dedicated ``handlers`` package, decorate their class with
+the package’s registration helper, and are auto-imported at module import time.
+The tables below highlight the specifics for each subsystem.
+
+### Formatter Handlers
+| Item | Location / Notes |
+| --- | --- |
+| Directory | `src/gregg_limper/formatter/handlers/` |
+| Decorator | `formatter.handlers.register` |
+| Runtime API | `formatter.handlers.get(media_type)` |
+| When adding | Update `formatter/composer.py`’s `ORDER`, teach `formatter/classifier.py` how to populate the slice, and ensure the corresponding `Fragment` class implements `content_text` for RAG ingestion. |
+
+### Command Cogs
+| Item | Location / Notes |
+| --- | --- |
+| Directory | `src/gregg_limper/commands/handlers/` |
+| Decorator | `commands.register_cog` |
+| Runtime API | `commands.setup(bot)` attaches every registered cog |
+| When adding | Provide any Discord slash command definitions within the Cog, note that modules are imported eagerly, and run the bot (or `pytest tests/test_commands_setup.py`) to validate registration. |
+
+### Tool Handlers
+| Item | Location / Notes |
+| --- | --- |
+| Directory | `src/gregg_limper/tools/handlers/` |
+| Decorator | `tools.register_tool` |
+| Runtime API | `tools.get_registered_tool_specs()` / `tools.get_tool_entry(name)` |
+| When adding | Return a `ToolResult` from `run`, add or update tests in `tests/tools/`, consider logging/timeout behaviour, and document new configuration knobs if needed. |
 
 ## Development Notes
 

--- a/src/gregg_limper/tools/handlers/__init__.py
+++ b/src/gregg_limper/tools/handlers/__init__.py
@@ -1,11 +1,1 @@
-"""
-Import side-effects for tool handlers.
-
-Every module imported here should register itself with the tool registry using
-the :func:`gregg_limper.tools.register_tool` decorator.
-"""
-
-from __future__ import annotations
-
-# Import concrete tools so module-level decorators execute on import.
-from . import rag  # noqa: F401
+"""Tool handler package (imports are handled automatically)."""


### PR DESCRIPTION
- Align formatter, commands, and tools registries on the decorator + auto-import pattern; remove the tools lazy-loader, tidy command setup docs, and simplify handler init modules
- Expand README with a “Handler Registries” section that explains how to extend formatter handlers, command cogs, and tool handlers using the unified flow
- Ensure tool registry docstrings mirror formatter/command style and keep tests for tools/commands passing
