### PR TITLE
RAG ingestion now driven by reaction triggers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,6 +37,7 @@ MAINTENANCE_INTERVAL=3600
 RAG_OPT_IN_LOOKBACK_DAYS=180
 RAG_BACKFILL_CONCURRENCY=20
 RAG_VECTOR_SEARCH_K=3
+RAG_REACTION_EMOJIS=🔥,🧠,<:brain:123456789012345678>
 
 #------------------------------------------------------------------------------
 # Milvus vector store (set ENABLE_MILVUS=0 to disable)

--- a/src/gregg_limper/config/rag.py
+++ b/src/gregg_limper/config/rag.py
@@ -1,10 +1,15 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import os
 from pathlib import Path
+from typing import List
 
 _DEFAULT_SQLITE_PATH = (
     Path(__file__).resolve().parent.parent.parent / "data" / "memory.db"
 )
+
+
+def _split_triggers(raw: str) -> List[str]:
+    return [token.strip() for token in raw.split(",") if token.strip()]
 
 
 @dataclass
@@ -15,3 +20,6 @@ class Rag:
     MAINTENANCE_INTERVAL: int = int(os.getenv("MAINTENANCE_INTERVAL", "3600"))          # Seconds between maintenance tasks
     OPT_IN_LOOKBACK_DAYS: int = int(os.getenv("RAG_OPT_IN_LOOKBACK_DAYS", "180"))       # How far back to backfill user messages when they opt in to RAG
     BACKFILL_CONCURRENCY: int = int(os.getenv("RAG_BACKFILL_CONCURRENCY", "20"))        # Number of concurrent backfill tasks
+    REACTION_TRIGGERS: List[str] = field(
+        default_factory=lambda: _split_triggers(os.getenv("RAG_REACTION_EMOJIS", ""))
+    )                                                                                   # Emoji strings that trigger ingestion

--- a/src/gregg_limper/event_hooks/message_hook.py
+++ b/src/gregg_limper/event_hooks/message_hook.py
@@ -37,11 +37,13 @@ async def handle(client: discord.Client, message: discord.Message):
     bot_mentioned = bot_user in message.mentions if bot_user else False
 
     # 2) Add message to cache
-    # NOTE: The add message pipeline automatically handles formatting and ingestion.
-    # It will skip commands and feedback messages.
+    # NOTE: RAG ingestion is deferred to reaction triggers; this keeps memos warm without
+    # automatically pushing to long-term stores.
     cache = GLCache()  # Singleton instance
     try:
-        await cache.add_message(message.channel.id, message, bot_user=bot_user)
+        await cache.add_message(
+            message.channel.id, message, ingest=False, bot_user=bot_user
+        )
     except KeyError as e:
         logger.error(f"Failed to cache message {message.id}: {e}")
 

--- a/src/gregg_limper/event_hooks/message_hook.py
+++ b/src/gregg_limper/event_hooks/message_hook.py
@@ -61,4 +61,4 @@ async def handle(client: discord.Client, message: discord.Message):
         return
 
     response_text = await response.handle(message)
-    # await message.channel.send(response_text)
+    await message.channel.send(response_text)

--- a/src/gregg_limper/event_hooks/reaction_hook.py
+++ b/src/gregg_limper/event_hooks/reaction_hook.py
@@ -1,7 +1,118 @@
-import discord
+"""
+Handle reaction events that should trigger RAG ingestion.
+"""
+
+from __future__ import annotations
 
 import logging
+from typing import Any
+
+import discord
+
+from gregg_limper.config import core
+from gregg_limper.memory.cache import GLCache
+from gregg_limper.memory.cache import formatting as cache_formatting
+from gregg_limper.memory.cache.ingestion import evaluate_ingestion, ingest_message
+from gregg_limper.memory.rag.triggers import (
+    emoji_matches_trigger,
+    get_trigger_set,
+)
+
 logger = logging.getLogger(__name__)
 
-async def handle(client: discord.Client, reaction: discord.Reaction, user: discord.User):
-    logger.info(f"User {user.name} reacted with {reaction.emoji} in channel {reaction.message.channel.name} (ID: {reaction.message.channel.id})")
+
+async def handle(
+    client: discord.Client, reaction: discord.Reaction, user: discord.User
+) -> None:
+    """
+    Ingest the reacted message when both the emoji and author qualify.
+    """
+
+    message = reaction.message
+    channel = getattr(message, "channel", None)
+    guild = getattr(message, "guild", None)
+
+    # Skip DM messages and other contexts without guild/channel.
+    if guild is None or channel is None:
+        logger.debug(
+            "Ignoring reaction %s on message %s without guild/channel context",
+            reaction.emoji,
+            getattr(message, "id", "unknown"),
+        )
+        return
+
+    # Skip channels not in the configured set.
+    channel_id = getattr(channel, "id", None)
+    if channel_id not in core.CHANNEL_IDS:
+        return
+
+    # Skip reactions added by bots.
+    if getattr(message.author, "bot", False):
+        logger.debug(
+            "Skipping reaction-trigger ingest for bot-authored message %s", message.id
+        )
+        return
+
+    triggers = get_trigger_set()
+    if triggers.is_empty():
+        logger.debug("Reaction ingestion skipped: no trigger emojis configured.")
+        return
+
+    # Skip reactions that don't match the emoji trigger set.
+    if not emoji_matches_trigger(reaction.emoji, triggers):
+        return
+
+    cache = GLCache()
+
+    try:
+        cache_record = cache.get_memo_record(channel_id, message.id)
+        memo_present = True
+    except KeyError:
+        cache_record = None
+        memo_present = False
+
+    # Evaluate whether to ingest the message based on consent and existing RAG state.
+    should_ingest, resources = await evaluate_ingestion(
+        message,
+        ingest_requested=True,
+        memo_present=memo_present,
+        bot_user=getattr(client, "user", None),
+    )
+
+    if not should_ingest:
+        logger.debug(
+            "Reaction ingestion vetoed for message %s (likely missing consent).",
+            message.id,
+        )
+        return
+
+    if resources.sqlite:
+        logger.debug(
+            "Reaction ingestion skipped for message %s; already present in RAG.",
+            message.id,
+        )
+        return
+
+    if cache_record is None:
+        cache_record = await cache_formatting.format_for_cache(message)
+
+    # Ingest the message into the RAG stores.
+    try:
+        await ingest_message(channel_id, message, cache_record)
+    except Exception:
+        logger.exception("Failed to ingest message %s from reaction trigger", message.id)
+        return
+
+    actor: Any = (
+        getattr(user, "name", None)
+        or getattr(user, "display_name", None)
+        or getattr(user, "id", None)
+        or user
+    )
+    logger.info(
+        "Ingested message %s via reaction %s by %s in channel %s",
+        message.id,
+        reaction.emoji,
+        actor,
+        channel_id,
+    )

--- a/src/gregg_limper/event_hooks/reaction_hook.py
+++ b/src/gregg_limper/event_hooks/reaction_hook.py
@@ -46,19 +46,12 @@ async def handle(
     if channel_id not in core.CHANNEL_IDS:
         return
 
-    # Skip reactions added by bots.
-    if getattr(message.author, "bot", False):
-        logger.debug(
-            "Skipping reaction-trigger ingest for bot-authored message %s", message.id
-        )
-        return
-
+    # Skip reactions that don't match the emoji trigger set.
     triggers = get_trigger_set()
     if triggers.is_empty():
         logger.debug("Reaction ingestion skipped: no trigger emojis configured.")
         return
 
-    # Skip reactions that don't match the emoji trigger set.
     if not emoji_matches_trigger(reaction.emoji, triggers):
         return
 

--- a/src/gregg_limper/memory/rag/triggers.py
+++ b/src/gregg_limper/memory/rag/triggers.py
@@ -1,0 +1,166 @@
+"""
+Helpers for identifying emoji reactions that should trigger RAG ingestion.
+
+The trigger set is configurable via the ``RAG_REACTION_EMOJIS`` environment
+variable, which accepts a comma-separated list of emoji descriptors. Each entry
+may be one of:
+
+* A standard Unicode emoji literal, e.g. ``🧠``.
+* A Discord custom emoji spec like ``<:brain:1234567890>`` or ``<a:brain:123...>``.
+* A ``name:id`` pair (``brain:1234567890``) to improve readability.
+* A bare numeric ID (``1234567890``) or bare name (``brain``) as a fallback.
+
+This module normalizes those descriptors into lookup sets that can be safely
+matched against ``discord.Reaction.emoji`` payloads in both live hooks and
+offline backfill routines.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import logging
+import re
+from typing import Iterable, Sequence
+
+import discord
+
+from gregg_limper.config import rag as rag_cfg
+
+logger = logging.getLogger(__name__)
+
+_CUSTOM_FULL_RE = re.compile(r"^<a?:(?P<name>[\w~\-]+):(?P<id>\d+)>$")
+_NAMED_ID_RE = re.compile(r"^(?P<name>[\w~\-]+):(?P<id>\d+)$")
+_NUMERIC_ID_RE = re.compile(r"^\d+$")
+_NAME_RE = re.compile(r"^[\w~\-]+$")
+
+
+@dataclass(frozen=True)
+class TriggerSet:
+    """Normalized emoji triggers split across Unicode glyphs and custom ids/names."""
+
+    unicode_emojis: frozenset[str]
+    custom_ids: frozenset[int]
+    custom_names: frozenset[str]
+
+    def is_empty(self) -> bool:
+        return not (self.unicode_emojis or self.custom_ids or self.custom_names)
+
+
+def _parse_trigger_entry(entry: str) -> tuple[str | None, int | None, str | None]:
+    text = entry.strip()
+    if not text:
+        return None, None, None
+
+    match = _CUSTOM_FULL_RE.match(text)
+    if match:
+        return None, int(match.group("id")), match.group("name")
+
+    match = _NAMED_ID_RE.match(text)
+    if match:
+        return None, int(match.group("id")), match.group("name")
+
+    if _NUMERIC_ID_RE.match(text):
+        return None, int(text), None
+
+    if text.startswith(":") and text.endswith(":") and len(text) > 2:
+        return None, None, text[1:-1]
+
+    if _NAME_RE.match(text):
+        return None, None, text
+
+    # Fallback: treat as Unicode emoji literal (multi-codepoint safe)
+    return text, None, None
+
+
+def build_trigger_set(entries: Sequence[str]) -> TriggerSet:
+    unicode_values: set[str] = set()
+    custom_ids: set[int] = set()
+    custom_names: set[str] = set()
+
+    for raw in entries:
+        unicode_val, emoji_id, name = _parse_trigger_entry(raw)
+        if unicode_val:
+            unicode_values.add(unicode_val)
+        if emoji_id is not None:
+            custom_ids.add(emoji_id)
+        if name:
+            custom_names.add(name)
+
+    return TriggerSet(
+        unicode_emojis=frozenset(unicode_values),
+        custom_ids=frozenset(custom_ids),
+        custom_names=frozenset(custom_names),
+    )
+
+
+_CACHED_TRIGGERS: TriggerSet | None = None
+
+
+def get_trigger_set(force_refresh: bool = False) -> TriggerSet:
+    """
+    Return the configured trigger set, refreshing from config when requested.
+    """
+
+    global _CACHED_TRIGGERS
+    if _CACHED_TRIGGERS is None or force_refresh:
+        _CACHED_TRIGGERS = build_trigger_set(rag_cfg.REACTION_TRIGGERS)
+        if _CACHED_TRIGGERS.is_empty():
+            logger.info("RAG reaction triggers not configured; reaction ingestion disabled.")
+    return _CACHED_TRIGGERS
+
+
+def emoji_matches_trigger(
+    emoji: discord.PartialEmoji | discord.Emoji | str,
+    triggers: TriggerSet | None = None,
+) -> bool:
+    """
+    Return True if ``emoji`` matches the configured trigger set.
+    """
+
+    triggers = triggers or get_trigger_set()
+    if triggers.is_empty():
+        return False
+
+    if isinstance(emoji, str):
+        return emoji in triggers.unicode_emojis
+
+    emoji_id = getattr(emoji, "id", None)
+    if emoji_id is not None and emoji_id in triggers.custom_ids:
+        return True
+
+    emoji_name = getattr(emoji, "name", None)
+    if emoji_name and emoji_name in triggers.custom_names:
+        return True
+
+    # PartialEmoji.__str__ returns "<:name:id>" which may appear in config entries.
+    emoji_repr = str(emoji)
+    return emoji_repr in triggers.unicode_emojis
+
+
+def message_has_trigger_reaction(
+    message: discord.Message,
+    *,
+    triggers: TriggerSet | None = None,
+) -> bool:
+    """
+    Check whether ``message`` already has a reaction that matches the trigger set.
+    """
+
+    triggers = triggers or get_trigger_set()
+    if triggers.is_empty():
+        return False
+
+    reactions: Iterable[discord.Reaction] = getattr(message, "reactions", [])
+    for reaction in reactions:
+        if emoji_matches_trigger(reaction.emoji, triggers):
+            return True
+    return False
+
+
+__all__ = [
+    "TriggerSet",
+    "build_trigger_set",
+    "get_trigger_set",
+    "emoji_matches_trigger",
+    "message_has_trigger_reaction",
+]

--- a/tests/event_hooks/test_reaction_hook.py
+++ b/tests/event_hooks/test_reaction_hook.py
@@ -37,7 +37,7 @@ def test_reaction_hook_ingests_when_trigger_matches(monkeypatch):
         reaction_hook.cache_formatting, "format_for_cache", fake_format_for_cache
     )
 
-    def _raise_key_error(cid, mid):
+    def _raise_key_error(_cid, mid):
         raise KeyError(mid)
 
     cache_stub = SimpleNamespace(get_memo_record=_raise_key_error)
@@ -68,8 +68,16 @@ def test_reaction_hook_ignores_non_trigger(monkeypatch):
         raise AssertionError("evaluate_ingestion should not be called")
 
     monkeypatch.setattr(reaction_hook, "evaluate_ingestion", fake_evaluate)
-    monkeypatch.setattr(reaction_hook, "ingest_message", lambda *args, **kwargs: ingested.append(args))
-    monkeypatch.setattr(reaction_hook, "GLCache", lambda: SimpleNamespace(get_memo_record=lambda *_: None))
+    monkeypatch.setattr(
+        reaction_hook,
+        "ingest_message",
+        lambda *args, **kwargs: ingested.append(args),
+    )
+    monkeypatch.setattr(
+        reaction_hook,
+        "GLCache",
+        lambda: SimpleNamespace(get_memo_record=lambda *_: None),
+    )
     monkeypatch.setattr(reaction_hook.core, "CHANNEL_IDS", [1])
 
     _setup_trigger_patches(monkeypatch, should_match=False)
@@ -88,3 +96,48 @@ def test_reaction_hook_ignores_non_trigger(monkeypatch):
     asyncio.run(reaction_hook.handle(client, reaction, user))
 
     assert ingested == []
+
+
+def test_reaction_hook_allows_bot_authored_message_when_trigger_matches(monkeypatch):
+    ingested = []
+
+    async def fake_evaluate(*args, **kwargs):
+        return True, ResourceState(memo=False, sqlite=False)
+
+    async def fake_ingest(channel_id, message, cache_message):
+        ingested.append(message.id)
+
+    _setup_trigger_patches(monkeypatch, should_match=True)
+
+    monkeypatch.setattr(reaction_hook, "evaluate_ingestion", fake_evaluate)
+    monkeypatch.setattr(reaction_hook, "ingest_message", fake_ingest)
+    async def fake_format_for_cache(message):
+        return {"message_id": message.id}
+
+    monkeypatch.setattr(
+        reaction_hook.cache_formatting,
+        "format_for_cache",
+        fake_format_for_cache,
+    )
+
+    def _raise_key_error(*_args, **_kwargs):
+        raise KeyError()
+
+    cache_stub = SimpleNamespace(get_memo_record=_raise_key_error)
+    monkeypatch.setattr(reaction_hook, "GLCache", lambda: cache_stub)
+    monkeypatch.setattr(reaction_hook.core, "CHANNEL_IDS", [1])
+
+    message = SimpleNamespace(
+        id=55,
+        author=SimpleNamespace(id=999, bot=True),
+        guild=SimpleNamespace(id=7),
+        channel=SimpleNamespace(id=1),
+        reactions=[],
+    )
+    reaction = SimpleNamespace(message=message, emoji="🧠")
+    user = SimpleNamespace(name="moderator")
+    client = SimpleNamespace(user=SimpleNamespace(id=123))
+
+    asyncio.run(reaction_hook.handle(client, reaction, user))
+
+    assert ingested == [55]

--- a/tests/event_hooks/test_reaction_hook.py
+++ b/tests/event_hooks/test_reaction_hook.py
@@ -1,0 +1,90 @@
+import asyncio
+from types import SimpleNamespace
+
+from gregg_limper.event_hooks import reaction_hook
+from gregg_limper.memory.cache.ingestion import ResourceState
+from gregg_limper.memory.rag.triggers import TriggerSet
+
+
+def _setup_trigger_patches(monkeypatch, *, should_match: bool):
+    triggers = TriggerSet(frozenset({"🧠"}), frozenset(), frozenset())
+
+    monkeypatch.setattr(reaction_hook, "get_trigger_set", lambda: triggers)
+    monkeypatch.setattr(
+        reaction_hook,
+        "emoji_matches_trigger",
+        lambda emoji, trig: should_match and emoji == "🧠",
+    )
+
+
+def test_reaction_hook_ingests_when_trigger_matches(monkeypatch):
+    ingested = []
+
+    async def fake_evaluate(*args, **kwargs):
+        return True, ResourceState(memo=False, sqlite=False)
+
+    async def fake_ingest(channel_id, message, cache_message):
+        ingested.append((channel_id, message.id, cache_message))
+
+    async def fake_format_for_cache(message):
+        return {"message_id": message.id}
+
+    _setup_trigger_patches(monkeypatch, should_match=True)
+
+    monkeypatch.setattr(reaction_hook, "evaluate_ingestion", fake_evaluate)
+    monkeypatch.setattr(reaction_hook, "ingest_message", fake_ingest)
+    monkeypatch.setattr(
+        reaction_hook.cache_formatting, "format_for_cache", fake_format_for_cache
+    )
+
+    def _raise_key_error(cid, mid):
+        raise KeyError(mid)
+
+    cache_stub = SimpleNamespace(get_memo_record=_raise_key_error)
+    monkeypatch.setattr(reaction_hook, "GLCache", lambda: cache_stub)
+
+    monkeypatch.setattr(reaction_hook.core, "CHANNEL_IDS", [1])
+
+    message = SimpleNamespace(
+        id=42,
+        author=SimpleNamespace(id=10, bot=False),
+        guild=SimpleNamespace(id=7),
+        channel=SimpleNamespace(id=1),
+        reactions=[],
+    )
+    reaction = SimpleNamespace(message=message, emoji="🧠")
+    user = SimpleNamespace(name="tester")
+    client = SimpleNamespace(user=SimpleNamespace(id=999))
+
+    asyncio.run(reaction_hook.handle(client, reaction, user))
+
+    assert ingested == [(1, 42, {"message_id": 42})]
+
+
+def test_reaction_hook_ignores_non_trigger(monkeypatch):
+    ingested = []
+
+    async def fake_evaluate(*args, **kwargs):
+        raise AssertionError("evaluate_ingestion should not be called")
+
+    monkeypatch.setattr(reaction_hook, "evaluate_ingestion", fake_evaluate)
+    monkeypatch.setattr(reaction_hook, "ingest_message", lambda *args, **kwargs: ingested.append(args))
+    monkeypatch.setattr(reaction_hook, "GLCache", lambda: SimpleNamespace(get_memo_record=lambda *_: None))
+    monkeypatch.setattr(reaction_hook.core, "CHANNEL_IDS", [1])
+
+    _setup_trigger_patches(monkeypatch, should_match=False)
+
+    message = SimpleNamespace(
+        id=43,
+        author=SimpleNamespace(id=10, bot=False),
+        guild=SimpleNamespace(id=7),
+        channel=SimpleNamespace(id=1),
+        reactions=[],
+    )
+    reaction = SimpleNamespace(message=message, emoji="💡")
+    user = SimpleNamespace(name="tester")
+    client = SimpleNamespace(user=SimpleNamespace(id=999))
+
+    asyncio.run(reaction_hook.handle(client, reaction, user))
+
+    assert ingested == []

--- a/tests/rag/test_backfill_parity.py
+++ b/tests/rag/test_backfill_parity.py
@@ -8,6 +8,7 @@ from gregg_limper.commands.handlers.rag_opt import _backfill_user_messages
 from gregg_limper.config import cache as cache_cfg
 from gregg_limper.config import core as core_cfg
 from gregg_limper.memory.cache import memo, formatting, ingestion
+from gregg_limper.memory.rag.triggers import TriggerSet
 
 
 def _run(coro):
@@ -97,6 +98,16 @@ def test_backfill_matches_live_ingestion(monkeypatch):
         ingested_backfill.append(kwargs["message_id"])
 
     monkeypatch.setattr(ingestion.rag, "ingest_cache_message", fake_ingest_backfill)
+
+    triggers = TriggerSet(frozenset({"🧠"}), frozenset(), frozenset())
+
+    monkeypatch.setattr(
+        "gregg_limper.commands.handlers.rag_opt.get_trigger_set", lambda: triggers
+    )
+    monkeypatch.setattr(
+        "gregg_limper.commands.handlers.rag_opt.message_has_trigger_reaction",
+        lambda message, *, triggers: True,
+    )
 
     _run(_backfill_user_messages(user, guild))
 

--- a/tests/rag/test_triggers.py
+++ b/tests/rag/test_triggers.py
@@ -1,0 +1,55 @@
+from types import SimpleNamespace
+
+from gregg_limper.memory.rag.triggers import (
+    TriggerSet,
+    build_trigger_set,
+    emoji_matches_trigger,
+    message_has_trigger_reaction,
+)
+
+
+class FakeEmoji:
+    def __init__(self, name: str | None = None, emoji_id: int | None = None):
+        self.name = name
+        self.id = emoji_id
+
+    def __str__(self) -> str:
+        if self.name is None or self.id is None:
+            return super().__str__()
+        return f"<:{self.name}:{self.id}>"
+
+
+def test_build_trigger_set_parses_mixed_entries():
+    triggers = build_trigger_set(
+        ["🧠", "<:brain:12345>", "sparkle:67890", "98765", ":thumbsup:", "rocket"]
+    )
+
+    assert isinstance(triggers, TriggerSet)
+    assert triggers.unicode_emojis == {"🧠"}
+    assert triggers.custom_ids == {12345, 67890, 98765}
+    assert triggers.custom_names == {"brain", "sparkle", "thumbsup", "rocket"}
+
+
+def test_emoji_matches_trigger_unicode_and_custom():
+    triggers = build_trigger_set(["🧠", "brain:12345", ":thumbsup:"])
+
+    assert emoji_matches_trigger("🧠", triggers)
+    assert not emoji_matches_trigger("💡", triggers)
+
+    assert emoji_matches_trigger(FakeEmoji("brain", 12345), triggers)
+    assert emoji_matches_trigger(FakeEmoji("thumbsup", None), triggers)
+    assert not emoji_matches_trigger(FakeEmoji("wave", 4321), triggers)
+
+
+def test_message_has_trigger_reaction_detects_any_match():
+    triggers = build_trigger_set(["🧠"])
+
+    msg = SimpleNamespace(
+        reactions=[
+            SimpleNamespace(emoji="💡"),
+            SimpleNamespace(emoji="🧠"),
+        ]
+    )
+
+    assert message_has_trigger_reaction(msg, triggers=triggers)
+


### PR DESCRIPTION
- Add configurable reaction triggers including unicode/custom emoji parsing
- Stop auto-ingesting live messages; hydrate/backfill only when reactions are present
- Allow reaction-triggered ingest for both user and bot-authored messages
- Update docs, sample env, and tests to cover trigger-driven flow